### PR TITLE
fix: Dont show inspector on long press if ShowInspectorOn.Shaking is set

### DIFF
--- a/lib/src/requests_inspector_widget.dart
+++ b/lib/src/requests_inspector_widget.dart
@@ -40,7 +40,9 @@ class RequestsInspector extends StatelessWidget {
                 onWillPop: () async =>
                     inspectorController.pageController.page == 0,
                 child: GestureDetector(
-                  onLongPress: inspectorController.showInspector,
+                  onLongPress: showInspectorOn != ShowInspectorOn.Shaking
+                    ? inspectorController.showInspector
+                    : null,
                   child: PageView(
                     controller: inspectorController.pageController,
                     physics: const NeverScrollableScrollPhysics(),


### PR DESCRIPTION
showInspectorOn parameter wasn't working properly. onLongPress click was always enabled even if ShowInspectorOn.Shaking is set. This PR fixes the bug.