### PR TITLE
feat: Show meaningful request body for graphql requests instead of query parameter

### DIFF
--- a/lib/src/graphql_inspector_link.dart
+++ b/lib/src/graphql_inspector_link.dart
@@ -32,9 +32,7 @@ class GraphQLInspectorLink extends Link {
         RequestDetails(
           requestName: request.operation.operationName,
           requestMethod: RequestMethod.POST,
-          requestBody: printNode(request.operation.document)
-              .replaceAll('\n', '')
-              .replaceAll('__typename', ''),
+          requestBody: request.variables,
           headers: responseContext?.headers,
           url: link.uri.toString(),
           responseBody: response.response,
@@ -55,9 +53,7 @@ class GraphQLInspectorLink extends Link {
         RequestDetails(
           requestName: request.operation.operationName ?? 'GraphQL',
           requestMethod: RequestMethod.WS,
-          requestBody: printNode(request.operation.document)
-              .replaceAll('\n', '')
-              .replaceAll('__typename', ''),
+          requestBody: request.variables,
           url: link.url,
           responseBody: response.response,
           statusCode: 200,


### PR DESCRIPTION
Show meaningful request body for graphql requests instead of a query parameter.

Before:
<img width="428" alt="image" src="https://github.com/Abdelazeem777/requests_inspector/assets/44924680/2e17b2b9-c1f1-48fa-9c07-3a044b75f7b9">

After:
<img width="428" alt="image" src="https://github.com/Abdelazeem777/requests_inspector/assets/44924680/bb8e4cdc-0ed8-40cf-baee-f86758c6293e">

