### PR TITLE
fix: hideInspectorBanner: true no longer crashes the app, wrap request inspector in Directionality

### DIFF
--- a/lib/src/requests_inspector_widget.dart
+++ b/lib/src/requests_inspector_widget.dart
@@ -56,17 +56,17 @@ class RequestsInspector extends StatelessWidget {
         : _child;
 
     if (!hideInspectorBanner && enabled)
-      widget = Directionality(
+      widget = Banner(
+        message: 'INSPECTOR',
         textDirection: TextDirection.ltr,
-        child: Banner(
-          message: 'INSPECTOR',
-          textDirection: TextDirection.ltr,
-          location: BannerLocation.topEnd,
-          child: widget,
-        ),
+        location: BannerLocation.topEnd,
+        child: widget,
       );
 
-    return widget;
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: widget,
+    );
   }
 
   bool _isSupportShaking() =>


### PR DESCRIPTION
`hideInspectorBanner: true` crashes the app, because the Directionality widget is only provided with Banner. This PR fixes this issue and wraps widget in Directionality, even if a banner isn't there.