### PR TITLE
dispose singleton when dispose notifier

### DIFF
--- a/lib/src/inspector_controller.dart
+++ b/lib/src/inspector_controller.dart
@@ -162,6 +162,7 @@ class InspectorController extends ChangeNotifier {
   @override
   void dispose() {
     if (_allowShaking) _shakeDetector.stopListening();
+    _singleton = null;
     super.dispose();
   }
 


### PR DESCRIPTION
# Problem
When running integration test, we will encounter `A InspectorController was used after being disposed.` error

![Simulator Screenshot - iPhone 16 - 2024-10-29 at 19 05 40](https://github.com/user-attachments/assets/e37b9b98-988b-4e2b-a0ad-a59a51120c45)


# Root cause
Because InspectorController is using singleton. After dispose the InspectorController, the singleton inside is still in use. When jumping from one test group to another test group, the app try to reopen the app, but it failed because the singleton has been release yet.

# Solution
reset singleton to null when dispose the notifier.

