### PR TITLE
When there is data from error, show error first

### DIFF
--- a/lib/src/requests_inspector_interceptor.dart
+++ b/lib/src/requests_inspector_interceptor.dart
@@ -68,7 +68,7 @@ class RequestsInspectorInterceptor extends Interceptor {
         headers: err.requestOptions.headers,
         queryParameters: queryParameters,
         requestBody: err.requestOptions.data,
-        responseBody: err.message,
+        responseBody: err.response?.data ?? err.message,
         sentTime: err.requestOptions.extra['startTime'],
         receivedTime: DateTime.now(),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: requests_inspector
 description: A Flutter package for logging REST-APIs and GraphQL requests and
   accessing it by Shaking your phone to get the RequestsInspector widget on your
   screen.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/Abdelazeem777/requests_inspector
 # we can add screenshots here using screenshots key
 # please check this link https://dart.dev/tools/pub/pubspec#screenshots


### PR DESCRIPTION
Some BE has handled the error with their own response. In this case, we should show the response data in advance.