### PR TITLE
fix: Added a custom contextMenuBuilder to all SelectableText widgets

### DIFF
--- a/lib/src/json_tree_view_widget.dart
+++ b/lib/src/json_tree_view_widget.dart
@@ -181,6 +181,20 @@ class JsonTreeView extends StatelessWidget {
               ),
           ],
         ),
+        contextMenuBuilder: (context, editableTextState) {
+          return AdaptiveTextSelectionToolbar.buttonItems(
+            anchors: editableTextState.contextMenuAnchors,
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                onPressed: () {
+                  editableTextState.copySelection(SelectionChangedCause.toolbar);
+                  editableTextState.hideToolbar();
+                },
+                type: ContextMenuButtonType.copy,
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/src/shared_widgets/request_details_page.dart
+++ b/lib/src/shared_widgets/request_details_page.dart
@@ -201,7 +201,22 @@ class RequestDetailsPage extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.all(6.0),
-      child: SelectableText(text, style: const TextStyle(fontSize: 16.0)),
+      child: SelectableText(text, style: const TextStyle(fontSize: 16.0),
+          contextMenuBuilder: (context, editableTextState) {
+          return AdaptiveTextSelectionToolbar.buttonItems(
+            anchors: editableTextState.contextMenuAnchors,
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                onPressed: () {
+                  editableTextState.copySelection(SelectionChangedCause.toolbar);
+                  editableTextState.hideToolbar();
+                },
+                type: ContextMenuButtonType.copy,
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
The error occurred because **SelectableText** widgets were trying to access the system context menu (for copy/paste operations) without an active text input connection, and since there's no active one `TextInput._instance._currentConnection` is null


So I added a custom contextMenuBuilder to all SelectableText widgets to provides a safe context menu to allow copying texts without relying on the system context