### PR TITLE
feat: Enable setting a default value for tree view appearance

### DIFF
--- a/lib/src/inspector_controller.dart
+++ b/lib/src/inspector_controller.dart
@@ -19,23 +19,31 @@ class InspectorController extends ChangeNotifier {
   factory InspectorController({
     bool enabled = false,
     ShowInspectorOn showInspectorOn = ShowInspectorOn.Shaking,
+    bool defaultTreeViewEnabled = true,
     StoppingRequestCallback? onStoppingRequest,
     StoppingResponseCallback? onStoppingResponse,
-  }) =>
-      _singleton ??= InspectorController._internal(
-        enabled: enabled,
-        showInspectorOn: showInspectorOn,
-        onStoppingRequest: onStoppingRequest,
-        onStoppingResponse: onStoppingResponse,
-      );
+  }) {
+    if (_singleton != null) {
+      return _singleton!;
+    }
+    return _singleton = InspectorController._internal(
+      enabled: enabled,
+      showInspectorOn: showInspectorOn,
+      defaultTreeViewEnabled: defaultTreeViewEnabled,
+      onStoppingRequest: onStoppingRequest,
+      onStoppingResponse: onStoppingResponse,
+    );
+  }
 
   InspectorController._internal({
     required bool enabled,
     required ShowInspectorOn showInspectorOn,
+    required bool defaultTreeViewEnabled,
     StoppingRequestCallback? onStoppingRequest,
     StoppingResponseCallback? onStoppingResponse,
   })  : _enabled = enabled,
         _showInspectorOn = showInspectorOn,
+        _isTreeView = defaultTreeViewEnabled,
         _onStoppingRequest = onStoppingRequest,
         _onStoppingResponse = onStoppingResponse {
     if (_enabled && _allowShaking)
@@ -65,7 +73,7 @@ class InspectorController extends ChangeNotifier {
   bool _requestStopperEnabled = false;
   bool _responseStopperEnabled = false;
   bool _isDarkMode = true;
-  bool _isTreeView = true;
+  bool _isTreeView;
 
   final _requestsList = <RequestDetails>[];
   RequestDetails? _selectedRequest;

--- a/lib/src/requests_inspector_widget.dart
+++ b/lib/src/requests_inspector_widget.dart
@@ -16,11 +16,13 @@ class RequestsInspector extends StatelessWidget {
     bool enabled = true,
     bool hideInspectorBanner = false,
     ShowInspectorOn showInspectorOn = ShowInspectorOn.Both,
+    bool defaultTreeViewEnabled = true,
     required Widget child,
     GlobalKey<NavigatorState>? navigatorKey,
   }) : _enabled = enabled,
        _hideInspectorBanner = hideInspectorBanner,
        _showInspectorOn = showInspectorOn,
+       _defaultTreeViewEnabled = defaultTreeViewEnabled,
        _child = child,
        _navigatorKey = navigatorKey;
 
@@ -28,6 +30,7 @@ class RequestsInspector extends StatelessWidget {
   final bool _enabled;
   final bool _hideInspectorBanner;
   final ShowInspectorOn _showInspectorOn;
+  final bool _defaultTreeViewEnabled;
   final Widget _child;
 
   final GlobalKey<NavigatorState>? _navigatorKey;
@@ -36,21 +39,23 @@ class RequestsInspector extends StatelessWidget {
   Widget build(BuildContext context) {
     var widget = _enabled
         ? ChangeNotifierProvider(
-            create: (context) => InspectorController(
-              enabled: _enabled,
-              showInspectorOn: _isSupportShaking()
-                  ? _showInspectorOn
-                  : ShowInspectorOn.LongPress,
-              onStoppingRequest: (requestDetails) => _showRequestEditorDialog(
-                context,
-                requestDetails: requestDetails,
-              ),
-              onStoppingResponse: (responseDetails) =>
-                  _showResponseEditorDialog(
-                context,
-                responseDetails: responseDetails,
-              ),
-            ),
+            create: (context) =>
+               InspectorController(
+                enabled: _enabled,
+                showInspectorOn: _isSupportShaking()
+                    ? _showInspectorOn
+                    : ShowInspectorOn.LongPress,
+                defaultTreeViewEnabled: _defaultTreeViewEnabled,
+                onStoppingRequest: (requestDetails) => _showRequestEditorDialog(
+                  context,
+                  requestDetails: requestDetails,
+                ),
+                onStoppingResponse: (responseDetails) =>
+                    _showResponseEditorDialog(
+                  context,
+                  responseDetails: responseDetails,
+                ),
+              ),  
             lazy: false,
             builder: (context, _) {
               return WillPopScope(


### PR DESCRIPTION
Adding an option for apps that use inspector to set a default value for enabling/disabling ison tree view to avoid needing to toggle it on and off on every single request 