### PR TITLE
fix: Fix Selectable text at normal view

### DIFF
--- a/lib/src/shared_widgets/request_details_page.dart
+++ b/lib/src/shared_widgets/request_details_page.dart
@@ -250,9 +250,27 @@ class RequestDetailsPage extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.all(6.0),
-      child: SelectableText(prettyprint),
+      child: SelectableText(
+        prettyprint,
+        contextMenuBuilder: (context, editableTextState) {
+          return AdaptiveTextSelectionToolbar.buttonItems(
+            anchors: editableTextState.contextMenuAnchors,
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                onPressed: () {
+                  editableTextState.copySelection(SelectionChangedCause.toolbar);
+                  editableTextState.hideToolbar();
+                },
+                type: ContextMenuButtonType.copy,
+              ),
+            ],
+          );
+        },
+      ),
+      
     );
   }
+  
 
   Widget _buildRequestNameAndStatus({
     required RequestMethod method,


### PR DESCRIPTION
There was another place that have SelectableText without AdaptiveTextSelectionToolbar and since the default menu relies on the textinput service, which requires an active text input connection, the error occurred on the normal view 