### PR TITLE
fix: Fix type mismatch exception

### DIFF
--- a/lib/src/json_pretty_converter.dart
+++ b/lib/src/json_pretty_converter.dart
@@ -24,13 +24,13 @@ class JsonPrettyConverter {
     else if (text == null)
       prettyprint = '';
     else if (text is bool)
-      prettyprint = text;
+      prettyprint = text.toString();
     else if (text is num)
-      prettyprint = text;
+      prettyprint = text.toString();
     else if (text is double)
-      prettyprint = text;
+      prettyprint = text.toString();
     else if (text is int)
-      prettyprint = text;
+      prettyprint = text.toString();
     else
       prettyprint = text.toString();
     return prettyprint;


### PR DESCRIPTION
Fixed  bug where the requests_inspector crashed with type mismatch errors when API responses contained primitive types (bool, int, double) instead of Map or List objects.

Error:

> type 'bool' is not a subtype of type 'String'

![uploaded_image_1767559198811](https://github.com/user-attachments/assets/af8555cd-04f1-4fde-9ee4-86c16e0defaf)


