### PR TITLE
chore: Update dependencies and resolve lint warnings

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -356,10 +356,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -486,7 +486,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.3.0"
+    version: "5.4.0"
   rxdart:
     dependency: transitive
     description:
@@ -499,10 +499,10 @@ packages:
     dependency: transitive
     description:
       name: sensors_plus
-      sha256: "89e2bfc3d883743539ce5774a2b93df61effde40ff958ecad78cd66b1a8b8d52"
+      sha256: "56e8cd4260d9ed8e00ecd8da5d9fdc8a1b2ec12345a750dfa51ff83fcf12e3fa"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   sensors_plus_platform_interface:
     dependency: transitive
     description:
@@ -576,10 +576,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/filters_dialog.dart
+++ b/lib/src/filters_dialog.dart
@@ -57,7 +57,7 @@ class _FiltersDialogState extends State<FiltersDialog> {
                 border: OutlineInputBorder(),
                 isDense: true,
               ),
-              value: _selectedMethod,
+              initialValue: _selectedMethod,
               items: [
                 const DropdownMenuItem<RequestMethod?>(
                   value: null,

--- a/lib/src/graphql_inspector_link.dart
+++ b/lib/src/graphql_inspector_link.dart
@@ -14,12 +14,13 @@ class GraphQLInspectorLink extends Link {
   Stream<Response> request(Request request, [NextLink? forward]) {
     final link = _link;
 
-    if (link is HttpLink)
+    if (link is HttpLink) {
       return _handleHttpRequest(link, request, forward);
-    else if (link is WebSocketLink)
+    } else if (link is WebSocketLink) {
       return _handleWebSocketRequest(link, request, forward);
-    else
+    } else {
       return link.request(request, forward);
+    }
   }
 
   Stream<Response> _handleHttpRequest(

--- a/lib/src/har_generator.dart
+++ b/lib/src/har_generator.dart
@@ -75,7 +75,7 @@ class HarGenerator {
               'receive': 0,
             },
             if (curlCommand != null && curlCommand.isNotEmpty)
-              'comment': 'cURL: ' + curlCommand,
+              'comment': 'cURL: $curlCommand',
           }
         ],
       }
@@ -122,7 +122,7 @@ class HarGenerator {
       }
       for (final file in body.files) {
         final filename = file.value.filename ?? 'file';
-        params.add({'name': file.key, 'value': '@' + filename});
+        params.add({'name': file.key, 'value': '@$filename'});
       }
       return {
         'mimeType': 'multipart/form-data',
@@ -208,11 +208,9 @@ class HarGenerator {
     if (q.isEmpty) return baseUrl;
     final qp = q
         .map((e) =>
-            Uri.encodeQueryComponent(e['name'].toString()) +
-            '=' +
-            Uri.encodeQueryComponent(e['value'].toString()))
+            '${Uri.encodeQueryComponent(e['name'].toString())}=${Uri.encodeQueryComponent(e['value'].toString())}')
         .join('&');
-    if (baseUrl.contains('?')) return baseUrl + '&' + qp;
-    return baseUrl + '?' + qp;
+    if (baseUrl.contains('?')) return '$baseUrl&$qp';
+    return '$baseUrl?$qp';
   }
 }

--- a/lib/src/inspector_controller.dart
+++ b/lib/src/inspector_controller.dart
@@ -106,11 +106,15 @@ class InspectorController extends ChangeNotifier {
   String? _requestStopperFilterUrl;
   int? _responseStopperFilterStatusCode;
   String? _responseStopperFilterUrl;
+
   // ------------------------------
 
   RequestMethod? get requestStopperFilterMethod => _requestStopperFilterMethod;
+
   String? get requestStopperFilterUrl => _requestStopperFilterUrl;
+
   int? get responseStopperFilterStatusCode => _responseStopperFilterStatusCode;
+
   String? get responseStopperFilterUrl => _responseStopperFilterUrl;
 
   bool get hasRequestStopperFilters =>
@@ -377,10 +381,10 @@ class InspectorController extends ChangeNotifier {
         mimeType: 'application/json',
       );
 
-      Share.shareXFiles(
-        [file],
+      SharePlus.instance.share(ShareParams(
+        files: [file],
         sharePositionOrigin: sharePositionOrigin,
-      );
+      ));
       return;
     } else {
       final curlCommandGenerator = CurlCommandGenerator(_selectedRequest!);
@@ -392,11 +396,10 @@ class InspectorController extends ChangeNotifier {
       requestShareContent =
           '================[cURL Command]=================\n$curlContent\n\n==================[Normal Log]===================\n$normalLogContent';
     }
-
-    Share.share(
-      requestShareContent,
+    SharePlus.instance.share(ShareParams(
+      text: requestShareContent,
       sharePositionOrigin: sharePositionOrigin,
-    );
+    ));
   }
 
   @override

--- a/lib/src/shared_widgets/inspector.dart
+++ b/lib/src/shared_widgets/inspector.dart
@@ -412,10 +412,14 @@ class Inspector extends StatelessWidget {
                 final selectedRequest = InspectorController().selectedRequest!;
                 final isHttp = _isHttp(selectedRequest);
 
+                if (!context.mounted) return;
+
                 var shareType =
                     isHttp ? await _showDialogShareType(context) : null;
 
                 if (shareType == null) return;
+
+                if (!context.mounted) return;
 
                 if (shareType == ShareType.Har) {
                   shareType = await _showHarFormatDialog(context);

--- a/lib/src/shared_widgets/inspector_option_switch.dart
+++ b/lib/src/shared_widgets/inspector_option_switch.dart
@@ -14,7 +14,7 @@ class InspectorOptionSwitch extends StatelessWidget {
   Widget build(BuildContext context) {
     return Switch(
       value: value,
-      activeColor: Colors.green,
+      activeThumbColor: Colors.green,
       activeTrackColor: Colors.grey[700],
       inactiveThumbColor: Colors.white,
       inactiveTrackColor: Colors.grey[700],

--- a/lib/src/shared_widgets/request_details_page.dart
+++ b/lib/src/shared_widgets/request_details_page.dart
@@ -292,10 +292,10 @@ class RequestDetailsPage extends StatelessWidget {
         decoration: BoxDecoration(
           color: cardColor,
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: borderColor.withOpacity(0.3)),
+          border: Border.all(color: borderColor.withAlpha(77)),
           boxShadow: [
             BoxShadow(
-              color: theme.shadowColor.withOpacity(0.05),
+              color: theme.shadowColor.withAlpha(13),
               blurRadius: 8,
               offset: const Offset(0, 2),
             ),

--- a/lib/src/shared_widgets/run_again_widget.dart
+++ b/lib/src/shared_widgets/run_again_widget.dart
@@ -11,7 +11,7 @@ class RunAgainButton extends StatefulWidget {
   final bool isDarkMode; // New parameter
 
   @override
-  _RunAgainButtonState createState() => _RunAgainButtonState();
+  State<RunAgainButton> createState() => _RunAgainButtonState();
 }
 
 class _RunAgainButtonState extends State<RunAgainButton> {

--- a/lib/src/stopper_filters_dialog.dart
+++ b/lib/src/stopper_filters_dialog.dart
@@ -81,7 +81,7 @@ class _StopperFiltersDialogState extends State<StopperFiltersDialog> {
                   border: OutlineInputBorder(),
                   isDense: true,
                 ),
-                value: _selectedMethod,
+                initialValue: _selectedMethod,
                 items: [
                   const DropdownMenuItem<RequestMethod?>(
                     value: null,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -484,10 +484,10 @@ packages:
     dependency: "direct main"
     description:
       name: sensors_plus
-      sha256: "89e2bfc3d883743539ce5774a2b93df61effde40ff958ecad78cd66b1a8b8d52"
+      sha256: "56e8cd4260d9ed8e00ecd8da5d9fdc8a1b2ec12345a750dfa51ff83fcf12e3fa"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   sensors_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,15 +13,15 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  connectivity_plus: ^6.1.4
+  connectivity_plus: ^6.1.5
   dio: ^5.8.0+1
   flutter:
     sdk: flutter
   gql: ^1.0.0+1
   graphql: ^5.2.1
-  graphql_flutter: ^5.2.0
+  graphql_flutter: ^5.2.1
   provider: ^6.1.5
-  sensors_plus: ^6.1.1
+  sensors_plus: ^7.0.0
   share_plus: ^12.0.1
 
 dev_dependencies:


### PR DESCRIPTION
Key changes include:
- Updated project dependencies.
- Replaced deprecated `value` with `initialValue` in `DropdownButtonFormField`.
- Added curly braces to an `if` statement block.
- Replaced deprecated `withOpacity` with `withAlpha`.
- Updated `share_plus` API usage to non-deprecated methods.
- Replaced deprecated `activeColor` with `activeThumbColor`.
- Fixed a private type in a public API warning in `RunAgainButton`.
- Added `context.mounted` checks to prevent using `BuildContext` across async gaps.